### PR TITLE
Refactor zshenv/zshrc: Properly separate rbenv and nodebrew initialization

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -3,7 +3,6 @@
 #=============================
 if [ -d ${HOME}/.rbenv  ] ; then
   export PATH="$HOME/.rbenv/bin:$PATH"
-  eval "$(rbenv init -)"
 fi
 
 #=============================
@@ -11,5 +10,4 @@ fi
 #=============================
 if [ -f ~/.nodebrew/nodebrew ]; then
   export PATH=$HOME/.nodebrew/current/bin:$PATH
-  nodebrew use v7.10.0
 fi

--- a/zshrc
+++ b/zshrc
@@ -122,17 +122,19 @@ alias less='less -R'
 
 source $ZSH/oh-my-zsh.sh
 
-# Customize to your needs...
-export PATH=/usr/local/sbin:$HOME/.rbenv/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+# rbenvの初期化（プロンプトの表示等にも関与）
+if type rbenv > /dev/null 2>&1; then
+  eval "$(rbenv init -)"
+fi
+
+# nodebrew
+if [ -f ~/.nodebrew/nodebrew ]; then
+  nodebrew use v7.10.0
+fi
 
 # Homebrew
 export PATH="/usr/local/bin:$PATH"
 export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"
-
-### Added by Nodebrew
-if [ -d ${HOME}/.nodebrew ] ; then
-  export PATH=$HOME/.nodebrew/current/bin:$PATH
-fi
 
 # Added by Rails binstubs
 export PATH="./bin:$PATH"


### PR DESCRIPTION
This PR reorganizes `~/.zshenv` and `~/.zshrc` to align with best practices:

- Move `rbenv init` from `.zshenv` to `.zshrc` to avoid unnecessary evaluation in non-interactive shells.
- Move `nodebrew use` from `.zshenv` to `.zshrc` for the same reason.
- Remove redundant `PATH` override in `.zshrc` that could conflict with other PATH modifications.
- Deduplicate and clean up `nodebrew` path management.

These changes ensure faster shell startup, reduce risk of conflicts, and follow the principle of minimal `.zshenv`.
