### PR TITLE
Integrate starship prompt into dotfiles bootstrap

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -41,6 +41,7 @@ brew "qt", link: true
 brew "rbenv"
 brew "redis"
 brew "rsync"
+brew "starship"
 brew "the_silver_searcher"
 brew "tig"
 brew "tmux"

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@
 - [ruby-build](https://github.com/rbenv/ruby-build)
 - [zsh](https://www.zsh.org/)
 - [Neovim + LazyVim](https://www.lazyvim.org/)
+- [starship](https://starship.rs/)
 
 ## Configs
 
 - rbenv (and ruby-build)
 - zshrc / zshenv / bashrc
 - Neovim config (LazyVim-based)
+- starship prompt config
 - vimrc / gvimrc
 - wezterm
 - powconfig / gitignore

--- a/bashrc
+++ b/bashrc
@@ -24,3 +24,7 @@ fi
 if [ -f "$HOME/.bashrc.local" ] ; then
   . "$HOME/.bashrc.local"
 fi
+
+if command -v starship >/dev/null 2>&1 ; then
+  eval "$(starship init bash)"
+fi

--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,7 @@ delete_old_files()
   rm -f "$HOME/.zshenv"
   rm -f "$HOME/.zshrc"
   rm -rf "$HOME/.config/nvim"
+  rm -f "$HOME/.config/starship.toml"
   rm -f "$HOME/.config/wezterm/wezterm.lua"
 }
 
@@ -81,6 +82,7 @@ symlink_files()
   link_file "$HOME/dotfiles/vimrc" "$HOME/.vimrc"
 
   link_file "$HOME/dotfiles/nvim" "$HOME/.config/nvim"
+  link_file "$HOME/dotfiles/starship.toml" "$HOME/.config/starship.toml"
 
   link_file "$HOME/dotfiles/zshenv" "$HOME/.zshenv"
   link_file "$HOME/dotfiles/zshrc" "$HOME/.zshrc"

--- a/starship.toml
+++ b/starship.toml
@@ -1,0 +1,27 @@
+add_newline = false
+
+format = "$directory$git_branch$git_status$fill$cmd_duration$line_break$character"
+
+[character]
+success_symbol = "[❯](bold green)"
+error_symbol = "[❯](bold red)"
+
+[directory]
+truncation_length = 4
+truncate_to_repo = false
+style = "bold cyan"
+
+[git_branch]
+symbol = " "
+style = "bold purple"
+
+[git_status]
+style = "bold yellow"
+
+[cmd_duration]
+min_time = 500
+format = "[$duration]($style) "
+style = "bold yellow"
+
+[fill]
+symbol = " "

--- a/zshrc
+++ b/zshrc
@@ -120,7 +120,9 @@ fi
 
 export EDITOR=nvim
 
-eval "$(direnv hook zsh)"
+if command -v direnv > /dev/null 2>&1; then
+  eval "$(direnv hook zsh)"
+fi
 
 # rbenv
 export PATH=$HOME/.rbenv/shims:$PATH

--- a/zshrc
+++ b/zshrc
@@ -144,3 +144,7 @@ else
 fi
 unset __conda_setup
 # <<< conda initialize <<<
+
+if command -v starship >/dev/null 2>&1 ; then
+  eval "$(starship init zsh)"
+fi


### PR DESCRIPTION
Summary:
- add starship to Brewfile
- add shared starship config at starship.toml
- symlink ~/.config/starship.toml via install.sh
- initialize starship in zshrc and bashrc
- document starship in README

Result:
- opening wezterm (zsh) loads starship prompt once starship is installed and install.sh is applied.