### PR TITLE
Rework setup flow into bootstrap/apply/verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,20 @@
 - wezterm
 - powconfig / gitignore
 
-## Usage
+## Setup Flow
 
 ```sh
-./install.sh
+# 1) Install packages from Brewfile
+./scripts/bootstrap.sh
+
+# 2) Apply dotfiles symlinks
+./scripts/apply.sh
+
+# 3) Verify commands and links
+./scripts/verify.sh
 ```
+
+`./install.sh` runs all three steps in order.
 
 ## Local Overrides
 

--- a/install.sh
+++ b/install.sh
@@ -2,101 +2,15 @@
 
 set -euo pipefail
 
-RBENV_ROOT="$HOME/.rbenv"
-RBENV_BIN="$RBENV_ROOT/bin/rbenv"
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-link_file()
-{
-  local src="$1"
-  local dst="$2"
-  mkdir -p "$(dirname "$dst")"
-  ln -sfn "$src" "$dst"
-}
+echo "[STEP] bootstrap"
+"$ROOT_DIR/scripts/bootstrap.sh"
 
-rbenv_install_or_update()
-{
-  echo "[CHECK]   rbenv"
-  if [ -d "$RBENV_ROOT" ]
-  then
-    echo "[UPDATE]  git pull rbenv"
-    cd "$RBENV_ROOT"
-    git pull origin master
-    ruby_build_install_or_update 1
-  else
-    echo "[INSTALL] git clone rbenv"
-    git clone https://github.com/rbenv/rbenv.git "$RBENV_ROOT"
-    ruby_build_install_or_update 1
-  fi
+echo "[STEP] apply"
+"$ROOT_DIR/scripts/apply.sh"
 
-  if [ -x "$RBENV_BIN" ] ; then
-    "$RBENV_BIN" rehash
-  fi
-}
+echo "[STEP] verify"
+"$ROOT_DIR/scripts/verify.sh"
 
-ruby_build_install_or_update()
-{
-  mkdir -p "$RBENV_ROOT/plugins"
-  cd "$RBENV_ROOT/plugins"
-
-  echo "[CHECK]   ruby-build"
-  if [ -d "$RBENV_ROOT/plugins/ruby-build" ]
-  then
-    echo "[UPDATE]  git pull ruby-build"
-    cd "$RBENV_ROOT/plugins/ruby-build"
-    git pull origin master
-  else
-    echo "[INSTALL] git clone ruby-build"
-    cd "$RBENV_ROOT/plugins"
-    git clone https://github.com/rbenv/ruby-build.git "$RBENV_ROOT/plugins/ruby-build"
-  fi
-}
-
-delete_old_files()
-{
-  echo "[DELETE] Delete the old files"
-  rm -f "$HOME/.bashrc"
-  rm -f "$HOME/.bundle/config"
-  rm -f "$HOME/.gemrc"
-  rm -f "$HOME/.gitignore"
-  rm -f "$HOME/.gvimrc"
-  rm -f "$HOME/.powconfig"
-  rm -f "$HOME/.railsrc"
-  rm -f "$HOME/.vimrc"
-  rm -f "$HOME/.zshenv"
-  rm -f "$HOME/.zshrc"
-  rm -rf "$HOME/.config/nvim"
-  rm -f "$HOME/.config/starship.toml"
-  rm -f "$HOME/.config/wezterm/wezterm.lua"
-}
-
-symlink_files()
-{
-  echo "[Symlink] Symlinking files"
-  link_file "$HOME/dotfiles/bashrc" "$HOME/.bashrc"
-  link_file "$HOME/dotfiles/bundle_config" "$HOME/.bundle/config"
-  link_file "$HOME/dotfiles/gemrc" "$HOME/.gemrc"
-  link_file "$HOME/dotfiles/gitignore" "$HOME/.gitignore"
-  link_file "$HOME/dotfiles/gvimrc" "$HOME/.gvimrc"
-  link_file "$HOME/dotfiles/powconfig" "$HOME/.powconfig"
-  link_file "$HOME/dotfiles/.railsrc" "$HOME/.railsrc"
-  link_file "$HOME/dotfiles/vimrc" "$HOME/.vimrc"
-
-  link_file "$HOME/dotfiles/nvim" "$HOME/.config/nvim"
-  link_file "$HOME/dotfiles/starship.toml" "$HOME/.config/starship.toml"
-
-  link_file "$HOME/dotfiles/zshenv" "$HOME/.zshenv"
-  link_file "$HOME/dotfiles/zshrc" "$HOME/.zshrc"
-
-  link_file "$HOME/dotfiles/wezterm.lua" "$HOME/.config/wezterm/wezterm.lua"
-}
-
-#
-# Main Start
-#
-rbenv_install_or_update 1
-delete_old_files 1
-symlink_files 1
-
-echo "[DONE]  All done."
-
-cd "$HOME"
+echo "[DONE] setup completed."

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+link_file() {
+  local src="$1"
+  local dst="$2"
+  mkdir -p "$(dirname "$dst")"
+  ln -sfn "$src" "$dst"
+}
+
+echo "[RUN] removing old links/files"
+rm -f "$HOME/.bashrc"
+rm -f "$HOME/.bundle/config"
+rm -f "$HOME/.gemrc"
+rm -f "$HOME/.gitignore"
+rm -f "$HOME/.gvimrc"
+rm -f "$HOME/.powconfig"
+rm -f "$HOME/.railsrc"
+rm -f "$HOME/.vimrc"
+rm -f "$HOME/.zshenv"
+rm -f "$HOME/.zshrc"
+rm -rf "$HOME/.config/nvim"
+rm -f "$HOME/.config/starship.toml"
+rm -f "$HOME/.config/wezterm/wezterm.lua"
+
+echo "[RUN] creating symlinks"
+link_file "$ROOT_DIR/bashrc" "$HOME/.bashrc"
+link_file "$ROOT_DIR/bundle_config" "$HOME/.bundle/config"
+link_file "$ROOT_DIR/gemrc" "$HOME/.gemrc"
+link_file "$ROOT_DIR/gitignore" "$HOME/.gitignore"
+link_file "$ROOT_DIR/gvimrc" "$HOME/.gvimrc"
+link_file "$ROOT_DIR/powconfig" "$HOME/.powconfig"
+link_file "$ROOT_DIR/.railsrc" "$HOME/.railsrc"
+link_file "$ROOT_DIR/vimrc" "$HOME/.vimrc"
+
+link_file "$ROOT_DIR/nvim" "$HOME/.config/nvim"
+link_file "$ROOT_DIR/starship.toml" "$HOME/.config/starship.toml"
+link_file "$ROOT_DIR/wezterm.lua" "$HOME/.config/wezterm/wezterm.lua"
+
+link_file "$ROOT_DIR/zshenv" "$HOME/.zshenv"
+link_file "$ROOT_DIR/zshrc" "$HOME/.zshrc"
+
+echo "[OK] apply completed."

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BREWFILE="$ROOT_DIR/Brewfile"
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "[ERROR] Homebrew is not installed."
+  echo "Install Homebrew first: https://brew.sh/"
+  exit 1
+fi
+
+if [ ! -f "$BREWFILE" ]; then
+  echo "[ERROR] Brewfile not found: $BREWFILE"
+  exit 1
+fi
+
+echo "[RUN] brew bundle --file $BREWFILE"
+brew bundle --file "$BREWFILE"
+
+echo "[OK] bootstrap completed."

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+errors=0
+
+check_cmd() {
+  local cmd="$1"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    echo "[OK] command found: $cmd"
+  else
+    echo "[NG] command missing: $cmd"
+    errors=$((errors + 1))
+  fi
+}
+
+check_link() {
+  local dst="$1"
+  local expected="$2"
+  if [ -L "$dst" ] && [ "$(readlink "$dst")" = "$expected" ]; then
+    echo "[OK] link: $dst -> $expected"
+  else
+    echo "[NG] link mismatch: $dst"
+    errors=$((errors + 1))
+  fi
+}
+
+echo "[RUN] command checks"
+check_cmd brew
+check_cmd git
+check_cmd zsh
+check_cmd nvim
+check_cmd starship
+check_cmd direnv
+
+echo "[RUN] symlink checks"
+check_link "$HOME/.zshrc" "$ROOT_DIR/zshrc"
+check_link "$HOME/.config/nvim" "$ROOT_DIR/nvim"
+check_link "$HOME/.config/starship.toml" "$ROOT_DIR/starship.toml"
+check_link "$HOME/.config/wezterm/wezterm.lua" "$ROOT_DIR/wezterm.lua"
+
+if [ "$errors" -gt 0 ]; then
+  echo "[FAIL] verify failed with $errors issue(s)."
+  exit 1
+fi
+
+echo "[OK] verify completed."


### PR DESCRIPTION
Summary:
- split setup into three scripts: bootstrap, apply, and verify
- make install.sh a compatibility wrapper that runs all three stages
- move package installation responsibility to bootstrap via brew bundle
- keep apply focused on symlinks only
- add verify checks for key commands and symlink integrity
- update README with staged setup flow

Why:
- improves reproducibility on clean macOS environments
- makes failures easier to diagnose by stage
- keeps re-runs safe and deterministic