### PR TITLE
Guard OpenClaw completion sourcing in zshrc

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -150,3 +150,8 @@ unset __conda_setup
 if command -v starship >/dev/null 2>&1 ; then
   eval "$(starship init zsh)"
 fi
+
+# OpenClaw Completion
+if [ -r "$HOME/.openclaw/completions/openclaw.zsh" ]; then
+  source "$HOME/.openclaw/completions/openclaw.zsh"
+fi


### PR DESCRIPTION
Summary:
- wrap OpenClaw completion sourcing with a readability check
- only source the completion script when the file exists and is readable

Why:
- avoids unconditional execution on shell startup
- keeps startup robust on machines where OpenClaw is not installed