### PR TITLE
Add nvim autoread for external file change detection

### DIFF
--- a/nvim/lua/config/autocmds.lua
+++ b/nvim/lua/config/autocmds.lua
@@ -1,1 +1,10 @@
 -- Keep this file for local autocmds.
+
+-- 外部プロセスによるファイル変更を自動リロード
+vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter", "CursorHold", "CursorHoldI" }, {
+  callback = function()
+    if vim.fn.mode() ~= "c" then
+      vim.cmd("silent! checktime")
+    end
+  end,
+})

--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -6,3 +6,4 @@ vim.opt.cursorline = true
 vim.opt.clipboard = "unnamedplus"
 vim.opt.splitright = true
 vim.opt.splitbelow = true
+vim.opt.autoread = true


### PR DESCRIPTION
## Summary

- `options.lua` に `vim.opt.autoread = true` を追加
- `autocmds.lua` に `FocusGained` / `BufEnter` / `CursorHold` / `CursorHoldI` をトリガーとする `checktime` オートコマンドを追加

外部プロセス（Claude Code 等）がファイルを書き換えた際に、nvim 側が自動でバッファをリロードできるようにする。

## Test plan

- [ ] nvim を再起動して設定が読み込まれることを確認
- [ ] 外部プロセスでファイルを変更し、カーソルを止めるか別ウィンドウからフォーカスを戻すと自動リロードされることを確認
- [ ] `:checktime` を手動実行しても動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)